### PR TITLE
Remove load_plugin_textdomain() call

### DIFF
--- a/wc-donation-platform.php
+++ b/wc-donation-platform.php
@@ -61,11 +61,6 @@ if (!class_exists('WCDP')) {
             new WCDP_Feedback();
             WCDP_Integrator::init();
 
-            //Load textdomain
-            add_action('init', function () {
-                load_plugin_textdomain('wc-donation-platform', false, WCDP_DIR . '/languages');
-            });
-
             //Add plugin action links
             add_filter('plugin_action_links_' . plugin_basename(__FILE__), array(__CLASS__, 'plugin_action_links'));
             add_filter('plugin_row_meta', array(__CLASS__, 'plugin_row_meta'), 10, 2);


### PR DESCRIPTION
> Reminder: if your plugin or theme is hosted on WordPress.org and is still using load_*_textdomain(), you can remove this call. Since WordPress 4.6, plugins and themes no longer need load_plugin_textdomain() or load_theme_textdomain().

https://make.wordpress.org/core/2024/10/21/i18n-improvements-6-7/

Not sure though why this deprecation notice is being triggered on `wc-donation-platform`, since translations are loaded correctly in `init` action AFAICT.

I'm getting this when testing WordPress 6.7 in staging:
> Notice: Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the wc-donation-platform domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the init action or later.