### PR TITLE
fix: override add-to-cart templates for subscriptions too

### DIFF
--- a/includes/class-wcdp-hooks.php
+++ b/includes/class-wcdp-hooks.php
@@ -221,6 +221,8 @@ class WCDP_Hooks
             case 'single-product/add-to-cart/simple.php':
             case 'single-product/add-to-cart/variable.php':
             case 'single-product/add-to-cart/grouped.php':
+            case 'single-product/add-to-cart/subscription.php':
+            case 'single-product/add-to-cart/variable-subscription.php':
                 if ($donable) {
                     $template = $path . 'single-product/add-to-cart/product.php';
                 }


### PR DESCRIPTION
Allows WC Subscription products to be used with Style 2 (one pager)

Note that there is an attempt to address this here already:
https://github.com/wc-donation/wc-donation-platform/blob/main/includes/integrations/woocommerce-subscriptions/class-wcdp-subscriptions.php#L297-L302
But it doesn't seem to work in 100% of scenarios.